### PR TITLE
KAFKA-12689: Move StreamsProducer to TaskManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
@@ -68,7 +68,8 @@ public interface ThreadMetadata {
     String restoreConsumerClientId();
 
     /**
-     * Client IDs of the Kafka producers used by the stream thread.
+     * Client IDs of the Kafka producers used by the stream thread. This function always returns a singleton starting
+     * from release 4.0.
      *
      * @return client IDs of the Kafka producers
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -17,16 +17,11 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
@@ -35,17 +30,11 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
-import static org.apache.kafka.streams.internals.StreamsConfigUtils.processingMode;
-import static org.apache.kafka.streams.processor.internals.ClientUtils.getThreadProducerClientId;
 
 class ActiveTaskCreator {
     private final TopologyMetadata topologyMetadata;
@@ -55,11 +44,8 @@ class ActiveTaskCreator {
     private final ChangelogReader storeChangelogReader;
     private final ThreadCache cache;
     private final Time time;
-    private final String threadId;
     private final Logger log;
     private final Sensor createTaskSensor;
-    private final StreamsProducer threadProducer;
-    private final ProcessingMode processingMode;
     private final boolean stateUpdaterEnabled;
 
     ActiveTaskCreator(final TopologyMetadata topologyMetadata,
@@ -69,9 +55,7 @@ class ActiveTaskCreator {
                       final ChangelogReader storeChangelogReader,
                       final ThreadCache cache,
                       final Time time,
-                      final KafkaClientSupplier clientSupplier,
                       final String threadId,
-                      final UUID processId,
                       final Logger log,
                       final boolean stateUpdaterEnabled) {
         this.topologyMetadata = topologyMetadata;
@@ -81,40 +65,15 @@ class ActiveTaskCreator {
         this.storeChangelogReader = storeChangelogReader;
         this.cache = cache;
         this.time = time;
-        this.threadId = threadId;
         this.log = log;
         this.stateUpdaterEnabled = stateUpdaterEnabled;
 
         createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
-        processingMode = processingMode(applicationConfig);
-
-        log.info("Creating thread producer client");
-
-        final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());
-        final LogContext logContext = new LogContext(threadIdPrefix);
-
-        threadProducer = new StreamsProducer(
-            applicationConfig,
-            threadId,
-            clientSupplier,
-            processId,
-            logContext,
-            time);
-    }
-
-    public void reInitializeThreadProducer() {
-        threadProducer.resetProducer();
-    }
-
-    StreamsProducer threadProducer() {
-        if (processingMode != EXACTLY_ONCE_V2) {
-            throw new IllegalStateException("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
-        }
-        return threadProducer;
     }
 
     // TODO: convert to StreamTask when we remove TaskManager#StateMachineTask with mocks
     public Collection<Task> createTasks(final Consumer<byte[], byte[]> consumer,
+                                        final StreamsProducer producer,
                                         final Map<TaskId, Set<TopicPartition>> tasksToBeCreated) {
         final List<Task> createdTasks = new ArrayList<>();
 
@@ -148,6 +107,7 @@ class ActiveTaskCreator {
                     taskId,
                     partitions,
                     consumer,
+                    producer,
                     logContext,
                     topology,
                     stateManager,
@@ -160,11 +120,12 @@ class ActiveTaskCreator {
 
     private RecordCollector createRecordCollector(final TaskId taskId,
                                                   final LogContext logContext,
-                                                  final ProcessorTopology topology) {
+                                                  final ProcessorTopology topology,
+                                                  final StreamsProducer producer) {
         return new RecordCollectorImpl(
             logContext,
             taskId,
-            threadProducer,
+            producer,
             applicationConfig.defaultProductionExceptionHandler(),
             streamsMetrics,
             topology
@@ -178,7 +139,8 @@ class ActiveTaskCreator {
      */
     StreamTask createActiveTaskFromStandby(final StandbyTask standbyTask,
                                            final Set<TopicPartition> inputPartitions,
-                                           final Consumer<byte[], byte[]> consumer) {
+                                           final Consumer<byte[], byte[]> consumer,
+                                           final StreamsProducer producer) {
         if (!inputPartitions.equals(standbyTask.inputPartitions)) {
             log.warn("Detected unmatched input partitions for task {} when recycling it from standby to active", standbyTask.id);
         }
@@ -186,7 +148,8 @@ class ActiveTaskCreator {
         standbyTask.prepareRecycle();
         standbyTask.stateMgr.transitionTaskType(Task.TaskType.ACTIVE);
 
-        final RecordCollector recordCollector = createRecordCollector(standbyTask.id, getLogContext(standbyTask.id), standbyTask.topology);
+        final RecordCollector recordCollector = createRecordCollector(standbyTask.id, getLogContext(standbyTask.id), standbyTask.topology,
+            producer);
         final StreamTask task = new StreamTask(
             standbyTask.id,
             inputPartitions,
@@ -211,11 +174,12 @@ class ActiveTaskCreator {
     private StreamTask createActiveTask(final TaskId taskId,
                                         final Set<TopicPartition> inputPartitions,
                                         final Consumer<byte[], byte[]> consumer,
+                                        final StreamsProducer producer,
                                         final LogContext logContext,
                                         final ProcessorTopology topology,
                                         final ProcessorStateManager stateManager,
                                         final InternalProcessorContext<Object, Object> context) {
-        final RecordCollector recordCollector = createRecordCollector(taskId, logContext, topology);
+        final RecordCollector recordCollector = createRecordCollector(taskId, logContext, topology, producer);
 
         final StreamTask task = new StreamTask(
             taskId,
@@ -238,32 +202,9 @@ class ActiveTaskCreator {
         return task;
     }
 
-    void closeThreadProducerIfNeeded() {
-        try {
-            threadProducer.close();
-        } catch (final RuntimeException e) {
-            throw new StreamsException("Thread producer encounter error trying to close.", e);
-        }
-    }
-
-    Map<MetricName, Metric> producerMetrics() {
-        return threadProducer.metrics()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> (Metric) e.getValue()));
-    }
-
-    Set<String> producerClientIds() {
-        return Collections.singleton(getThreadProducerClientId(threadId));
-    }
-
     private LogContext getLogContext(final TaskId taskId) {
         final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());
         final String logPrefix = threadIdPrefix + String.format("%s [%s] ", "task", taskId);
         return new LogContext(logPrefix);
-    }
-
-    public double totalProducerBlockedTime() {
-        return threadProducer.totalBlockedTime();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -73,6 +73,7 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getConsumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getRestoreConsumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getSharedAdminClientId;
+import static org.apache.kafka.streams.processor.internals.ClientUtils.getThreadProducerClientId;
 
 public class StreamThread extends Thread {
 
@@ -374,9 +375,7 @@ public class StreamThread extends Thread {
             changelogReader,
             cache,
             time,
-            clientSupplier,
             threadId,
-            processId,
             log,
             stateUpdaterEnabled);
         final StandbyTaskCreator standbyTaskCreator = new StandbyTaskCreator(
@@ -389,6 +388,15 @@ public class StreamThread extends Thread {
             log,
             stateUpdaterEnabled);
 
+        log.info("Creating thread producer client");
+        final StreamsProducer threadProducer = new StreamsProducer(
+            config,
+            threadId,
+            clientSupplier,
+            processId,
+            logContext,
+            time);
+
         final TaskManager taskManager = new TaskManager(
             time,
             changelogReader,
@@ -396,6 +404,7 @@ public class StreamThread extends Thread {
             logPrefix,
             activeTaskCreator,
             standbyTaskCreator,
+            threadProducer,
             new Tasks(new LogContext(logPrefix)),
             topologyMetadata,
             adminClient,
@@ -1212,7 +1221,7 @@ public class StreamThread extends Thread {
             state().name(),
             getConsumerClientId(getName()),
             getRestoreConsumerClientId(getName()),
-            taskManager.producerClientIds(),
+            getThreadProducerClientId(getName()),
             adminClientId,
             Collections.emptySet(),
             Collections.emptySet());
@@ -1249,7 +1258,7 @@ public class StreamThread extends Thread {
             state().name(),
             getConsumerClientId(getName()),
             getRestoreConsumerClientId(getName()),
-            taskManager.producerClientIds(),
+            getThreadProducerClientId(getName()),
             adminClientId,
             activeTasksMetadata,
             standbyTasksMetadata
@@ -1297,8 +1306,8 @@ public class StreamThread extends Thread {
         leaveGroupRequested.set(true);
     }
 
-    public Map<MetricName, Metric> producerMetrics() {
-        return taskManager.producerMetrics();
+    public Map<MetricName, ? extends Metric> producerMetrics() {
+        return taskManager.threadProducer().metrics();
     }
 
     public Map<MetricName, Metric> consumerMetrics() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
@@ -41,7 +41,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
 
     private final String restoreConsumerClientId;
 
-    private final Set<String> producerClientIds;
+    private final String producerClientId;
 
     // the admin client should be shared among all threads, so the client id should be the same;
     // we keep it at the thread-level for user's convenience and possible extensions in the future
@@ -51,13 +51,13 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                               final String threadState,
                               final String mainConsumerClientId,
                               final String restoreConsumerClientId,
-                              final Set<String> producerClientIds,
+                              final String producerClientId,
                               final String adminClientId,
                               final Set<TaskMetadata> activeTasks,
                               final Set<TaskMetadata> standbyTasks) {
         this.mainConsumerClientId = mainConsumerClientId;
         this.restoreConsumerClientId = restoreConsumerClientId;
-        this.producerClientIds = Collections.unmodifiableSet(producerClientIds);
+        this.producerClientId = producerClientId;
         this.adminClientId = adminClientId;
         this.threadName = threadName;
         this.threadState = threadState;
@@ -92,7 +92,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
     }
 
     public Set<String> producerClientIds() {
-        return producerClientIds;
+        return Collections.singleton(producerClientId);
     }
 
     public String adminClientId() {
@@ -114,7 +114,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                Objects.equals(standbyTasks, that.standbyTasks) &&
                mainConsumerClientId.equals(that.mainConsumerClientId) &&
                restoreConsumerClientId.equals(that.restoreConsumerClientId) &&
-               Objects.equals(producerClientIds, that.producerClientIds) &&
+               Objects.equals(producerClientId, that.producerClientId) &&
                adminClientId.equals(that.adminClientId);
     }
 
@@ -127,7 +127,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
             standbyTasks,
             mainConsumerClientId,
             restoreConsumerClientId,
-            producerClientIds,
+            producerClientId,
             adminClientId);
     }
 
@@ -140,7 +140,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                 ", standbyTasks=" + standbyTasks +
                 ", consumerClientId=" + mainConsumerClientId +
                 ", restoreConsumerClientId=" + restoreConsumerClientId +
-                ", producerClientIds=" + producerClientIds +
+                ", producerClientId=" + producerClientId +
                 ", adminClientId=" + adminClientId +
                 '}';
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -344,7 +344,7 @@ public class KafkaStreamsTest {
                 "DEAD",
                 "",
                 "",
-                Collections.emptySet(),
+                "",
                 "",
                 Collections.emptySet(),
                 Collections.emptySet()

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -766,6 +766,7 @@ public class StreamThreadTest {
             null,
             null,
             null,
+            null,
             new Tasks(new LogContext()),
             topologyMetadata,
             null,
@@ -850,8 +851,7 @@ public class StreamThreadTest {
         expect(task.committedOffsets()).andStubReturn(Collections.emptyMap());
         expect(task.highWaterMark()).andStubReturn(Collections.emptyMap());
         final ActiveTaskCreator activeTaskCreator = mock(ActiveTaskCreator.class);
-        expect(activeTaskCreator.createTasks(anyObject(), anyObject())).andStubReturn(Collections.singleton(task));
-        expect(activeTaskCreator.producerClientIds()).andStubReturn(Collections.singleton("producerClientId"));
+        expect(activeTaskCreator.createTasks(anyObject(), anyObject(), anyObject())).andStubReturn(Collections.singleton(task));
 
         final StandbyTaskCreator standbyTaskCreator = mock(StandbyTaskCreator.class);
         expect(standbyTaskCreator.createTasks(anyObject())).andStubReturn(Collections.emptySet());
@@ -870,6 +870,7 @@ public class StreamThreadTest {
             null,
             activeTaskCreator,
             standbyTaskCreator,
+            null,
             new Tasks(new LogContext()),
             topologyMetadata,
             null,
@@ -1103,7 +1104,6 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -1127,7 +1127,6 @@ public class StreamThreadTest {
     @Test
     public void shouldNotReturnDataAfterTaskMigrated() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final InternalTopologyBuilder internalTopologyBuilder = EasyMock.createNiceMock(InternalTopologyBuilder.class);
         expect(internalTopologyBuilder.fullSourceTopicNames()).andReturn(Collections.singletonList(topic1)).times(2);
 
@@ -1194,7 +1193,6 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -1217,7 +1215,6 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -2197,7 +2194,6 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2230,7 +2226,6 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2262,7 +2257,6 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchHandleCorruptionOnTaskCorruptedExceptionPath() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         consumer.subscribe((Collection<String>) anyObject(), anyObject());
@@ -2328,7 +2322,6 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTimeoutExceptionFromHandleCorruptionAndInvokeExceptionHandler() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2399,7 +2392,6 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTaskMigratedExceptionOnOnTaskCorruptedExceptionPath() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2471,7 +2463,6 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldEnforceRebalanceWhenTaskCorruptedExceptionIsThrownForAnActiveTask() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2542,7 +2533,6 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldNotEnforceRebalanceWhenTaskCorruptedExceptionIsThrownForAnInactiveTask() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2744,6 +2734,7 @@ public class StreamThreadTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldTransmitTaskManagerMetrics() {
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
@@ -2760,17 +2751,17 @@ public class StreamThreadTest {
             null,
             new MockTime());
         final Map<MetricName, Metric> dummyProducerMetrics = singletonMap(testMetricName, testMetric);
+        final StreamsProducer producer = EasyMock.createNiceMock(StreamsProducer.class);
 
-        expect(taskManager.producerMetrics()).andReturn(dummyProducerMetrics);
-        EasyMock.replay(taskManager);
+        expect(taskManager.threadProducer()).andReturn(producer);
+        expect((Map<MetricName, Metric>) producer.metrics()).andReturn(dummyProducerMetrics);
+        EasyMock.replay(taskManager, producer);
 
-        final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
 
-        assertThat(dummyProducerMetrics, is(thread.producerMetrics()));
+        assertThat(thread.producerMetrics(), is(dummyProducerMetrics));
     }
 
     @Test
@@ -2845,7 +2836,6 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumer, consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
@@ -41,9 +41,7 @@ public class ThreadMetadataImplTest {
     public static final String THREAD_STATE = "thread state";
     public static final String MAIN_CONSUMER_CLIENT_ID = "main Consumer ClientID";
     public static final String RESTORE_CONSUMER_CLIENT_ID = "restore Consumer ClientID";
-    public static final String CLIENT_ID_1 = "client Id 1";
-    public static final String CLIENT_ID_2 = "client Id 2";
-    public static final Set<String> PRODUCER_CLIENT_IDS = mkSet(CLIENT_ID_1, CLIENT_ID_2);
+    public static final String PRODUCER_CLIENT_ID = "client Id";
     public static final TaskId TASK_ID_0 = new TaskId(1, 2);
     public static final TaskId TASK_ID_1 = new TaskId(1, 1);
     public static final TopicPartition TP_0_0 = new TopicPartition("t", 0);
@@ -75,7 +73,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -96,7 +94,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -112,7 +110,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -128,7 +126,7 @@ public class ThreadMetadataImplTest {
             "different",
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -144,7 +142,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             "different",
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -160,7 +158,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             "different",
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -176,7 +174,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            mkSet(CLIENT_ID_1),
+            "different",
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -192,7 +190,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             "different",
             ACTIVE_TASKS,
             STANDBY_TASKS
@@ -208,7 +206,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             mkSet(TM_0),
             STANDBY_TASKS
@@ -224,7 +222,7 @@ public class ThreadMetadataImplTest {
             THREAD_STATE,
             MAIN_CONSUMER_CLIENT_ID,
             RESTORE_CONSUMER_CLIENT_ID,
-            PRODUCER_CLIENT_IDS,
+            PRODUCER_CLIENT_ID,
             ADMIN_CLIENT_ID,
             ACTIVE_TASKS,
             mkSet(TM_0)


### PR DESCRIPTION
Move ownership of `StreamsProducer` from `ActiveTaskCreator` to `TaskManager` to simplify current code.

 - It was considered to remove StreamsProducer completely, however, with the removal of EOSv1 it has not lost its purpose completely, since it enables the RecordCollectors to avoid double `initTxn/beginTxn` using internal state (`transactionInitialized`, `transactionInFlight`). So it’s essentially making those operations idempotent, while they are not idempotent in the Producer API.
 - Instead, I propose to move the ownership of the `StreamsProducer` from the `ActiveTaskCreator` to `TaskManager`, to sit side-by-side with the consumers.
 - I also removed the internal producer client ID collection and replaced it by a single string. We could deprecate `Set<String> producerClientIds`  in favour of a `String producerClientId`. Wasn't sure if we want to include it in this PR already.

Testing through updated unit tests.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
