### PR TITLE
KAFKA-12689: Simplify handle revocation logic

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -109,7 +109,7 @@ public class ActiveTaskCreatorTest {
             time,
             threadId,
             lc.logger(ActiveTaskCreator.class),
-			false
+            false
         );
 
         assertThat(


### PR DESCRIPTION
Simplify logic for commit on partition (and therefore task) revocation.

Only call commitOffsetOrTransaction and related functions if there is anything
to commit for the revoked tasks. Otherwise, only call postCommit on the revoked
tasks.

No additional testing logic required.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
