### PR TITLE
KSTREAMS-6420: Define initial record types for the consumer offset topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsInitializeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsInitializeRequestManager.java
@@ -122,7 +122,7 @@ public class StreamsInitializeRequestManager implements RequestManager {
             logger.error("Error during Streams initialization: ", exception);
         } else {
             // todo: handle success
-            logger.info("Streams initialization successful", exception);
+            logger.info("Streams initialization successful");
         }
     }
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupCurrentMemberAssignmentKey",
+  "validVersions": "8",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "8",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "8",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupCurrentMemberAssignmentKey",
-  "validVersions": "8",
+  "name": "StreamsGroupCurrentMemberAssignmentKey",
+  "validVersions": "14",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "8",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupCurrentMemberAssignmentValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "MemberEpoch", "versions": "0+", "type": "int32",
+      "about": "The current member epoch that is expected from the member in the heartbeat request." },
+    { "name": "PreviousMemberEpoch", "versions": "0+", "type": "int32",
+      "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
+    { "name": "State", "versions": "0+", "type": "int8",
+      "about": "The member state. See ConsumerGroupMember.MemberState for the possible values." },
+    { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions assigned to (or owned by) this member." },
+    { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions that must be revoked by this member." }
+  ],
+  "commonStructs": [
+    { "name": "TopicPartitions", "versions": "0+", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic Id." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partition Ids." }
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -38,9 +38,9 @@
   "commonStructs": [
     { "name": "TaskId", "versions": "0+", "fields": [
       { "name": "Subtopology", "type": "string", "versions": "0+",
-        "about": "subtopology ID" },
+        "about": "The subtopology identifier." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "partitions" }
+        "about": "The partitions of the input topics processed by this member." }
     ]}
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupCurrentMemberAssignmentValue",
+  "name": "StreamsGroupCurrentMemberAssignmentValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
@@ -25,7 +25,7 @@
     { "name": "PreviousMemberEpoch", "versions": "0+", "type": "int32",
       "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
     { "name": "State", "versions": "0+", "type": "int8",
-      "about": "The member state. See ConsumerGroupMember.MemberState for the possible values." },
+      "about": "The member state. See StreamsGroupMember.MemberState for the possible values." },
     { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
       "about": "The partitions assigned to (or owned by) this member." },
     { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -26,17 +26,21 @@
       "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
     { "name": "State", "versions": "0+", "type": "int8",
       "about": "The member state. See StreamsGroupMember.MemberState for the possible values." },
-    { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
-      "about": "The partitions assigned to (or owned by) this member." },
-    { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",
-      "about": "The partitions that must be revoked by this member." }
+    { "name": "ActiveTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned active tasks for this streams client." },
+    { "name": "StandbyTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned standby tasks for this streams client." },
+    { "name": "WarmupTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned warming up tasks for this streams client." },
+    { "name": "ActiveTasksPendingRevocation", "versions": "0+", "type": "[]TaskId",
+      "about": "The active tasks that must be revoked by this member." }
   ],
   "commonStructs": [
-    { "name": "TopicPartitions", "versions": "0+", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
-        "about": "The topic Id." },
+    { "name": "TaskId", "versions": "0+", "fields": [
+      { "name": "Subtopology", "type": "string", "versions": "0+",
+        "about": "subtopology ID" },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partition Ids." }
+        "about": "partitions" }
     ]}
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMemberMetadataKey",
+  "validVersions": "5",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "5",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "5",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMemberMetadataKey",
-  "validVersions": "5",
+  "name": "StreamsGroupMemberMetadataKey",
+  "validVersions": "11",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "5",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMemberMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "InstanceId", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The (optional) instance id." },
+    { "name": "RackId", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The (optional) rack id." },
+    { "name": "ClientId", "versions": "0+", "type": "string",
+      "about": "The client id." },
+    { "name": "ClientHost", "versions": "0+", "type": "string",
+      "about": "The client host." },
+    { "name": "SubscribedTopicNames", "versions": "0+", "type": "[]string",
+      "about": "The list of subscribed topic names." },
+    { "name": "SubscribedTopicRegex", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The subscribed topic regular expression." },
+    { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+      "about": "The rebalance timeout" },
+    { "name": "ServerAssignor", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The server assignor to use; or null if not used." },
+    { "name": "ClassicMemberMetadata", "versions": "0+", "nullableVersions": "0+", "type": "ClassicMemberMetadata",
+      "default": null, "taggedVersions": "0+", "tag": 0,
+      "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
+      "fields": [
+        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+",
+          "about": "The session timeout if the consumer uses the classic protocol." },
+        { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
+          "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",
+          "fields": [
+            { "name": "Name", "type": "string", "versions": "0+",
+              "about": "The protocol name."},
+            { "name": "Metadata", "type": "bytes", "versions": "0+",
+              "about": "The protocol metadata."}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -28,29 +28,41 @@
       "about": "The client id." },
     { "name": "ClientHost", "versions": "0+", "type": "string",
       "about": "The client host." },
-    { "name": "SubscribedTopicNames", "versions": "0+", "type": "[]string",
-      "about": "The list of subscribed topic names." },
-    { "name": "SubscribedTopicRegex", "versions": "0+", "nullableVersions": "0+", "type": "string",
-      "about": "The subscribed topic regular expression." },
     { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
       "about": "The rebalance timeout" },
-    { "name": "ServerAssignor", "versions": "0+", "nullableVersions": "0+", "type": "string",
-      "about": "The server assignor to use; or null if not used." },
-    { "name": "ClassicMemberMetadata", "versions": "0+", "nullableVersions": "0+", "type": "ClassicMemberMetadata",
-      "default": null, "taggedVersions": "0+", "tag": 0,
-      "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
+
+    { "name": "TopologyHash", "type": "bytes", "versions": "0+",
+      "about": "The hash of the topology. " },
+    { "name": "Assignor", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": null,
+      "about": "The desired assignor. " },
+
+    { "name": "ProcessId", "type": "string", "versions": "0+",
+      "about": "Identity of the streams instance that may have multiple consumers. " },
+    { "name": "HostInfo", "type": "HostInfo", "versions": "0+",
+      "about": "Host information for running interactive queries on this instance. ",
       "fields": [
-        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+",
-          "about": "The session timeout if the consumer uses the classic protocol." },
-        { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
-          "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",
-          "fields": [
-            { "name": "Name", "type": "string", "versions": "0+",
-              "about": "The protocol name."},
-            { "name": "Metadata", "type": "bytes", "versions": "0+",
-              "about": "The protocol metadata."}
-          ]
-        }
+        { "name": "Host", "type": "string", "versions": "0+",
+          "about": "Host for running interactive queries on this instance." },
+        { "name": "Port", "type": "int32", "versions": "0+",
+          "about": "Port for running interactive queries on this instance." }
+      ]
+    },
+    // TODO: maybe it would be nice to just stuff this info into "AssignmentConfigs", since it's quite specific
+    { "name": "ClientTags", "type": "[]KeyValue", "versions": "0+",
+      "about": "Used for rack-aware assignment algorithm. Null if unchanged since last heartbeat." },
+
+    { "name": "UserData", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "Opaque user data to be passed to the client-side assignor." },
+    { "name": "AssignmentConfigs", "type": "[]KeyValue", "versions": "0+",
+      "about": "Generic array of assignment configuration strings." }
+  ],
+  "commonStructs": [
+    { "name": "KeyValue", "versions": "0+",
+      "fields": [
+        { "name": "Key", "type": "string", "versions": "0+",
+          "about": "key of the config" },
+        { "name": "Value", "type": "string", "versions": "0+",
+          "about": "value of the config" }
       ]
     }
   ]

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMemberMetadataValue",
+  "name": "StreamsGroupMemberMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -29,17 +29,17 @@
     { "name": "ClientHost", "versions": "0+", "type": "string",
       "about": "The client host." },
     { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
-      "about": "The rebalance timeout" },
+      "about": "The rebalance timeout." },
 
     { "name": "TopologyHash", "type": "bytes", "versions": "0+",
       "about": "The hash of the topology. " },
     { "name": "Assignor", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": null,
-      "about": "The desired assignor. " },
+      "about": "The desired assignor. If set to null, the vote goes towards the broker taking a pick." },
 
     { "name": "ProcessId", "type": "string", "versions": "0+",
-      "about": "Identity of the streams instance that may have multiple consumers. " },
+      "about": "Identity of the streams instance that may have multiple consumers." },
     { "name": "HostInfo", "type": "HostInfo", "versions": "0+",
-      "about": "Host information for running interactive queries on this instance. ",
+      "about": "Host information for running interactive queries on this instance.",
       "fields": [
         { "name": "Host", "type": "string", "versions": "0+",
           "about": "Host for running interactive queries on this instance." },
@@ -49,10 +49,10 @@
     },
     // TODO: maybe it would be nice to just stuff this info into "AssignmentConfigs", since it's quite specific
     { "name": "ClientTags", "type": "[]KeyValue", "versions": "0+",
-      "about": "Used for rack-aware assignment algorithm. Null if unchanged since last heartbeat." },
+      "about": "Used for rack-aware assignment algorithm." },
 
     { "name": "UserData", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "default": "null",
-      "about": "Opaque user data to be passed to the client-side assignor." },
+      "about": "Opaque user data to be passed to the client-side assignor. Null for server-side assignors." },
     { "name": "AssignmentConfigs", "type": "[]KeyValue", "versions": "0+",
       "about": "Generic array of assignment configuration strings." }
   ],

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMetadataKey",
+  "validVersions": "3",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "3",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMetadataKey",
-  "validVersions": "3",
+  "name": "StreamsGroupMetadataKey",
+  "validVersions": "9",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "3",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Epoch", "versions": "0+", "type": "int32",
+      "about": "The group epoch." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMetadataValue",
+  "name": "StreamsGroupMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupPartitionMetadataKey",
+  "validVersions": "4",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "4",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupPartitionMetadataKey",
-  "validVersions": "4",
+  "name": "StreamsGroupPartitionMetadataKey",
+  "validVersions": "10",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "4",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupPartitionMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
+      "about": "The list of topic metadata.", "fields": [
+      { "name": "TopicId", "versions": "0+", "type": "uuid",
+        "about": "The topic id." },
+      { "name": "TopicName", "versions": "0+", "type": "string",
+        "about": "The topic name." },
+      { "name": "NumPartitions", "versions": "0+", "type": "int32",
+        "about": "The number of partitions of the topic." },
+      { "name": "PartitionMetadata", "versions": "0+", "type": "[]PartitionMetadata",
+        "about": "Partitions mapped to a set of racks. If the rack information is unavailable for all the partitions, an empty list is stored", "fields": [
+          { "name": "Partition", "versions": "0+", "type": "int32",
+            "about": "The partition number." },
+          { "name": "Racks", "versions": "0+", "type": "[]string",
+            "about": "The set of racks that the partition is mapped to." }
+      ]}
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupPartitionMetadataValue",
+  "name": "StreamsGroupPartitionMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -20,7 +20,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    // TODO: Do we need to update this???
     { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -20,6 +20,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    // TODO: Do we need to update this???
     { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMemberKey",
+  "validVersions": "7",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "7",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "7",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMemberKey",
-  "validVersions": "7",
+  "name": "StreamsGroupTargetAssignmentMemberKey",
+  "validVersions": "13",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "7",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMemberValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "TopicPartitions", "versions": "0+", "type": "[]TopicPartition",
+      "about": "The assigned partitions.", "fields": [
+      { "name": "TopicId", "versions": "0+", "type": "uuid" },
+      { "name": "Partitions", "versions": "0+", "type": "[]int32" }
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMemberValue",
+  "name": "StreamsGroupTargetAssignmentMemberValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMetadataKey",
+  "validVersions": "6",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "6",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMetadataKey",
-  "validVersions": "6",
+  "name": "StreamsGroupTargetAssignmentMetadataKey",
+  "validVersions": "12",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "6",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "AssignmentEpoch", "versions": "0+", "type": "int32",
+      "about": "The assignment epoch." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMetadataValue",
+  "name": "StreamsGroupTargetAssignmentMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyKey.json
@@ -16,23 +16,11 @@
 // The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "StreamsGroupTargetAssignmentMemberValue",
-  "validVersions": "0",
-  "flexibleVersions": "0+",
+  "name": "StreamsGroupTopologyKey",
+  "validVersions": "15",
+  "flexibleVersions": "none",
   "fields": [
-    { "name": "ActiveTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned active tasks for this streams client." },
-    { "name": "StandbyTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned standby tasks for this streams client." },
-    { "name": "WarmupTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned warming up tasks for this streams client." }
-  ],
-  "commonStructs": [
-    { "name": "TaskId", "versions": "0+", "fields": [
-      { "name": "Subtopology", "type": "string", "versions": "0+",
-        "about": "The subtopology identifier." },
-      { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partitions of the input topics processed by this member." }
-    ]}
+    { "name": "GroupId", "type": "string", "versions": "3",
+      "about": "The group id." }
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
-  "apiKey": 77,
-  "type": "request",
-  "listeners": ["zkBroker", "broker"],
-  "name": "StreamsInitializeRequest",
+  "type": "data",
+  "name": "StreamsGroupTopologyValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
-      "about": "The group identifier." },
+    { "name": "TopologyHash", "type": "bytes", "versions": "0+",
+      "about": "The hash of the topology. " },
     { "name":  "Topology", "type": "[]Subtopology", "versions": "0+",
       "about": "The sub-topologies of the streams application.",
       "fields": [
@@ -33,19 +32,19 @@
         { "name": "SinkTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology writes to." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
+          "about": "The set of state changelog topics associated with this subtopology. " },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+          "about": "The set of source topics that are internally created repartition topics. " }
       ]
     }
   ],
   "commonStructs": [
     { "name": "TopicConfig", "versions": "0+", "fields": [
-        { "name": "key", "type": "string", "versions": "0+",
-          "about": "The key of the topic-level configuration." },
-        { "name": "value", "type": "string", "versions": "0+",
-          "about": "The value of the topic-level configuration," }
-      ]
+      { "name": "key", "type": "string", "versions": "0+",
+        "about": "The key of the topic-level configuration." },
+      { "name": "value", "type": "string", "versions": "0+",
+        "about": "The value of the topic-level configuration," }
+    ]
     },
     { "name": "TopicInfo", "versions": "0+", "fields": [
       { "name": "Name", "type": "string", "versions": "0+",


### PR DESCRIPTION
The goal is to define initial record types for storing group metadata. The aim is roughly match the data represented in the RPCs and the KIP-848 records. There is an extra record for the topology that is called when `StreamsInitialize` is called.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
