### PR TITLE
KSTREAMS-5764: Implement InitStreamsApp RPC in the group coordinator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsInitializeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsInitializeRequestManager.java
@@ -122,7 +122,7 @@ public class StreamsInitializeRequestManager implements RequestManager {
             logger.error("Error during Streams initialization: ", exception);
         } else {
             // todo: handle success
-            logger.info("Streams initialization successful", exception);
+            logger.info("Streams initialization successful");
         }
     }
 }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -20,7 +20,7 @@ import kafka.common.OffsetAndMetadata
 import kafka.server.{KafkaConfig, ReplicaManager, RequestLocal}
 import kafka.utils.Implicits.MapExtensionMethods
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, StreamsInitializeRequestData, StreamsInitializeResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
@@ -71,6 +71,15 @@ private[group] class GroupCoordinatorAdapter(
   ): CompletableFuture[ConsumerGroupHeartbeatResponseData] = {
     FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
       s"The old group coordinator does not support ${ApiKeys.CONSUMER_GROUP_HEARTBEAT.name} API."
+    ))
+  }
+
+  override def streamsInitialize(
+                                   context: RequestContext,
+                                   request: StreamsInitializeRequestData
+                                 ): CompletableFuture[StreamsInitializeResponseData] = {
+    FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
+      s"The old group coordinator does not support ${ApiKeys.STREAMS_INITIALIZE.name} API."
     ))
   }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -256,6 +256,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS => handleGetTelemetrySubscriptionsRequest(request)
         case ApiKeys.PUSH_TELEMETRY => handlePushTelemetryRequest(request)
         case ApiKeys.LIST_CLIENT_METRICS_RESOURCES => handleListClientMetricsResources(request)
+        case ApiKeys.STREAMS_INITIALIZE => handleStreamsInitialize(request).exceptionally(handleError)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -3865,6 +3866,33 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
 
+  }
+
+  def handleStreamsInitialize(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    val streamsInitializeRequest = request.body[StreamsInitializeRequest]
+
+    // TODO: Check ACLs on CREATE TOPIC & DESCRIBE_CONFIGS
+
+    if (!config.isNewGroupCoordinatorEnabled) {
+      // The API is not supported by the "old" group coordinator (the default). If the
+      // new one is not enabled, we fail directly here.
+      requestHelper.sendMaybeThrottle(request, streamsInitializeRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      CompletableFuture.completedFuture[Unit](())
+    } else if (!authHelper.authorize(request.context, READ, GROUP, streamsInitializeRequest.data.groupId)) {
+      requestHelper.sendMaybeThrottle(request, streamsInitializeRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
+      CompletableFuture.completedFuture[Unit](())
+    } else {
+      groupCoordinator.streamsInitialize(
+        request.context,
+        streamsInitializeRequest.data,
+      ).handle[Unit] { (response, exception) =>
+        if (exception != null) {
+          requestHelper.sendMaybeThrottle(request, streamsInitializeRequest.getErrorResponse(exception))
+        } else {
+          requestHelper.sendMaybeThrottle(request, new StreamsInitializeResponse(response))
+        }
+      }
+    }
   }
 
   def handleGetTelemetrySubscriptionsRequest(request: RequestChannel.Request): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -21,7 +21,7 @@ import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.{JoinGroupCallbac
 import kafka.server.RequestLocal
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors.{InvalidGroupIdException, UnsupportedVersionException}
-import org.apache.kafka.common.message.{ConsumerGroupHeartbeatRequestData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupHeartbeatRequestData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, StreamsInitializeRequestData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember
 import org.apache.kafka.common.message.OffsetDeleteRequestData.{OffsetDeleteRequestPartition, OffsetDeleteRequestTopic, OffsetDeleteRequestTopicCollection}
@@ -72,6 +72,22 @@ class GroupCoordinatorAdapterTest {
       .setGroupId("group")
 
     val future = adapter.consumerGroupHeartbeat(ctx, request)
+
+    assertTrue(future.isDone)
+    assertTrue(future.isCompletedExceptionally)
+    assertFutureThrows(future, classOf[UnsupportedVersionException])
+  }
+
+  @Test
+  def testStreamsInitialize(): Unit = {
+    val groupCoordinator = mock(classOf[GroupCoordinator])
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+
+    val ctx = makeContext(ApiKeys.STREAMS_INITIALIZE, ApiKeys.STREAMS_INITIALIZE.latestVersion)
+    val request = new StreamsInitializeRequestData()
+      .setGroupId("group")
+
+    val future = adapter.streamsInitialize(ctx, request)
 
     assertTrue(future.isDone)
     assertTrue(future.isCompletedExceptionally)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -7081,6 +7081,68 @@ class KafkaApisTest extends Logging {
     val response = verifyNoThrottling[ConsumerGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code, response.data.errorCode)
   }
+  
+  def testStreamsInitializeRequest(): Unit = {
+    val streamsInitializeRequest = new StreamsInitializeRequestData().setGroupId("group")
+
+    val requestChannelRequest = buildRequest(new StreamsInitializeRequest.Builder(streamsInitializeRequest, true).build())
+
+    val future = new CompletableFuture[StreamsInitializeResponseData]()
+    when(groupCoordinator.streamsInitialize(
+      requestChannelRequest.context,
+      streamsInitializeRequest
+    )).thenReturn(future)
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG -> "true"
+    ))
+    kafkaApis.handle(requestChannelRequest, RequestLocal.NoCaching)
+
+    val streamsInitializeResponse = new StreamsInitializeResponseData()
+
+    future.complete(streamsInitializeResponse)
+    val response = verifyNoThrottling[StreamsInitializeResponse](requestChannelRequest)
+    assertEquals(streamsInitializeResponse, response.data)
+  }
+
+  @Test
+  def testStreamsInitializeRequestFutureFailed(): Unit = {
+    val streamsInitializeRequest = new StreamsInitializeRequestData().setGroupId("group")
+
+    val requestChannelRequest = buildRequest(new StreamsInitializeRequest.Builder(streamsInitializeRequest, true).build())
+
+    val future = new CompletableFuture[StreamsInitializeResponseData]()
+    when(groupCoordinator.streamsInitialize(
+      requestChannelRequest.context,
+      streamsInitializeRequest
+    )).thenReturn(future)
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG -> "true"
+    ))
+    kafkaApis.handle(requestChannelRequest, RequestLocal.NoCaching)
+
+    future.completeExceptionally(Errors.FENCED_MEMBER_EPOCH.exception)
+    val response = verifyNoThrottling[StreamsInitializeResponse](requestChannelRequest)
+    assertEquals(Errors.FENCED_MEMBER_EPOCH.code, response.data.errorCode)
+  }
+
+  @Test
+  def testStreamsInitializeRequestAuthorizationFailed(): Unit = {
+    val streamsInitializeRequest = new StreamsInitializeRequestData().setGroupId("group")
+
+    val requestChannelRequest = buildRequest(new StreamsInitializeRequest.Builder(streamsInitializeRequest, true).build())
+
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+    when(authorizer.authorize(any[RequestContext], any[util.List[Action]]))
+      .thenReturn(Seq(AuthorizationResult.DENIED).asJava)
+    kafkaApis = createKafkaApis(
+      authorizer = Some(authorizer),
+      overrideProperties = Map(GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG -> "true")
+    )
+    kafkaApis.handle(requestChannelRequest, RequestLocal.NoCaching)
+
+    val response = verifyNoThrottling[StreamsInitializeResponse](requestChannelRequest)
+    assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code, response.data.errorCode)
+  }
 
   @Test
   def testConsumerGroupDescribe(): Unit = {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
@@ -591,9 +591,9 @@ public class CoordinatorRecordHelpers {
                 return new StreamsGroupTopologyValue.TopicInfo().setName(topicInfo.name()).setTopicConfigs(topicConfigs);
             }).collect(Collectors.toList());
 
-            value.topology().add(new StreamsGroupTopologyValue.Subtopology().setSourceTopics(subtopology.sourceTopics())
-                .setSinkTopics(subtopology.sinkTopics()).setRepartitionSourceTopics(repartitionSourceTopics)
-                .setStateChangelogTopics(stateChangelogTopics));
+            value.topology().add(new StreamsGroupTopologyValue.Subtopology().setSubtopology(subtopology.subtopology())
+                .setSourceTopics(subtopology.sourceTopics()).setSinkTopics(subtopology.sinkTopics())
+                .setRepartitionSourceTopics(repartitionSourceTopics).setStateChangelogTopics(stateChangelogTopics));
         });
 
         return new CoordinatorRecord(new ApiMessageAndVersion(new StreamsGroupTopologyKey().setGroupId(groupId), (short) 15),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
@@ -38,6 +39,8 @@ import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
@@ -46,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This class contains helper methods to create records stored in
@@ -559,4 +563,41 @@ public class CoordinatorRecordHelpers {
         );
         return topics;
     }
+
+    /**
+     * Creates a StreamsTopology record.
+     *
+     * @param groupId                   The consumer group id.
+     * @param subtopologies             The subtopologies in the new topology.
+     * @return The record.
+     */
+    public static CoordinatorRecord newStreamsGroupTopologyRecord(String groupId,
+                                                                  List<StreamsInitializeRequestData.Subtopology> subtopologies) {
+        StreamsGroupTopologyValue value = new StreamsGroupTopologyValue();
+        subtopologies.forEach(subtopology -> {
+            List<StreamsGroupTopologyValue.TopicInfo> repartitionSourceTopics = subtopology.repartitionSourceTopics().stream()
+                .map(topicInfo -> {
+                    List<StreamsGroupTopologyValue.TopicConfig> topicConfigs = topicInfo.topicConfigs().stream()
+                        .map(config -> new StreamsGroupTopologyValue.TopicConfig().setKey(config.key()).setValue(config.value()))
+                        .collect(Collectors.toList());
+                    return new StreamsGroupTopologyValue.TopicInfo().setName(topicInfo.name()).setTopicConfigs(topicConfigs)
+                        .setPartitions(topicInfo.partitions());
+                }).collect(Collectors.toList());
+
+            List<StreamsGroupTopologyValue.TopicInfo> stateChangelogTopics = subtopology.stateChangelogTopics().stream().map(topicInfo -> {
+                List<StreamsGroupTopologyValue.TopicConfig> topicConfigs = topicInfo.topicConfigs().stream()
+                    .map(config -> new StreamsGroupTopologyValue.TopicConfig().setKey(config.key()).setValue(config.value()))
+                    .collect(Collectors.toList());
+                return new StreamsGroupTopologyValue.TopicInfo().setName(topicInfo.name()).setTopicConfigs(topicConfigs);
+            }).collect(Collectors.toList());
+
+            value.topology().add(new StreamsGroupTopologyValue.Subtopology().setSourceTopics(subtopology.sourceTopics())
+                .setSinkTopics(subtopology.sinkTopics()).setRepartitionSourceTopics(repartitionSourceTopics)
+                .setStateChangelogTopics(stateChangelogTopics));
+        });
+
+        return new CoordinatorRecord(new ApiMessageAndVersion(new StreamsGroupTopologyKey().setGroupId(groupId), (short) 15),
+            new ApiMessageAndVersion(value, (short) 0));
+    }
+
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpers.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
  * This class contains helper methods to create records stored in
  * the __consumer_offsets topic.
  */
+@SuppressWarnings("ClassDataAbstractionCoupling")
 public class CoordinatorRecordHelpers {
     private CoordinatorRecordHelpers() {}
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -71,6 +73,20 @@ public interface GroupCoordinator {
     CompletableFuture<ConsumerGroupHeartbeatResponseData> consumerGroupHeartbeat(
         RequestContext context,
         ConsumerGroupHeartbeatRequestData request
+    );
+
+    /**
+     * Initialize a Streams Group.
+     *
+     * @param context           The request context.
+     * @param request           The StreamsHeartbeatRequest data.
+     *
+     * @return  A future yielding the response.
+     *          The error code(s) of the response are set to indicate the error(s) occurred during the execution.
+     */
+    CompletableFuture<StreamsInitializeResponseData> streamsInitialize(
+        RequestContext context,
+        StreamsInitializeRequestData request
     );
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -35,6 +35,8 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.errors.ApiException;
@@ -305,6 +307,22 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         ConsumerGroupHeartbeatRequestData request
     ) {
         return groupMetadataManager.consumerGroupHeartbeat(context, request);
+    }
+
+    /**
+     * Handles a StreamsInitialize request.
+     *
+     * @param context The request context.
+     * @param request The actual StreamsInitialize request.
+     *
+     * @return A Result containing the StreamsInitialize response and
+     *         a list of records to update the state machine.
+     */
+    public CoordinatorResult<StreamsInitializeResponseData, CoordinatorRecord> streamsInitialize(
+        RequestContext context,
+        StreamsInitializeRequestData request
+    ) {
+        return groupMetadataManager.streamsInitialize(context, request);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.InconsistentGroupProtocolException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
-import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedAssignorException;
@@ -1610,11 +1609,11 @@ public class GroupMetadataManager {
         // TODO: For the POC, only check if internal topics exist
         Set<String> missingTopics = new HashSet<>();
         for (StreamsInitializeRequestData.Subtopology subtopology : subtopologies) {
-             for (StreamsInitializeRequestData.TopicInfo topic : subtopology.stateChangelogTopics()) {
-                 if (metadataImage.topics().getTopic(topic.name()) == null) {
-                     missingTopics.add(topic.name());
-                 }
-             }
+            for (StreamsInitializeRequestData.TopicInfo topic : subtopology.stateChangelogTopics()) {
+                if (metadataImage.topics().getTopic(topic.name()) == null) {
+                    missingTopics.add(topic.name());
+                }
+            }
             for (StreamsInitializeRequestData.TopicInfo topic : subtopology.repartitionSourceTopics()) {
                 if (metadataImage.topics().getTopic(topic.name()) == null) {
                     missingTopics.add(topic.name());

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupCurrentMemberAssignmentKey",
+  "validVersions": "8",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "8",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "8",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupCurrentMemberAssignmentKey",
-  "validVersions": "8",
+  "name": "StreamsGroupCurrentMemberAssignmentKey",
+  "validVersions": "14",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "8",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupCurrentMemberAssignmentValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "MemberEpoch", "versions": "0+", "type": "int32",
+      "about": "The current member epoch that is expected from the member in the heartbeat request." },
+    { "name": "PreviousMemberEpoch", "versions": "0+", "type": "int32",
+      "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
+    { "name": "State", "versions": "0+", "type": "int8",
+      "about": "The member state. See ConsumerGroupMember.MemberState for the possible values." },
+    { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions assigned to (or owned by) this member." },
+    { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions that must be revoked by this member." }
+  ],
+  "commonStructs": [
+    { "name": "TopicPartitions", "versions": "0+", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic Id." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partition Ids." }
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -38,9 +38,9 @@
   "commonStructs": [
     { "name": "TaskId", "versions": "0+", "fields": [
       { "name": "Subtopology", "type": "string", "versions": "0+",
-        "about": "subtopology ID" },
+        "about": "The subtopology identifier." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "partitions" }
+        "about": "The partitions of the input topics processed by this member." }
     ]}
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupCurrentMemberAssignmentValue",
+  "name": "StreamsGroupCurrentMemberAssignmentValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
@@ -25,7 +25,7 @@
     { "name": "PreviousMemberEpoch", "versions": "0+", "type": "int32",
       "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
     { "name": "State", "versions": "0+", "type": "int8",
-      "about": "The member state. See ConsumerGroupMember.MemberState for the possible values." },
+      "about": "The member state. See StreamsGroupMember.MemberState for the possible values." },
     { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
       "about": "The partitions assigned to (or owned by) this member." },
     { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -26,17 +26,21 @@
       "about": "If the last epoch bump is lost before reaching the member, the member will retry with the previous epoch." },
     { "name": "State", "versions": "0+", "type": "int8",
       "about": "The member state. See StreamsGroupMember.MemberState for the possible values." },
-    { "name": "AssignedPartitions", "versions": "0+", "type": "[]TopicPartitions",
-      "about": "The partitions assigned to (or owned by) this member." },
-    { "name": "PartitionsPendingRevocation", "versions": "0+", "type": "[]TopicPartitions",
-      "about": "The partitions that must be revoked by this member." }
+    { "name": "ActiveTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned active tasks for this streams client." },
+    { "name": "StandbyTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned standby tasks for this streams client." },
+    { "name": "WarmupTasks", "versions": "0+", "type": "[]TaskId",
+      "about": "Currently assigned warming up tasks for this streams client." },
+    { "name": "ActiveTasksPendingRevocation", "versions": "0+", "type": "[]TaskId",
+      "about": "The active tasks that must be revoked by this member." }
   ],
   "commonStructs": [
-    { "name": "TopicPartitions", "versions": "0+", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
-        "about": "The topic Id." },
+    { "name": "TaskId", "versions": "0+", "fields": [
+      { "name": "Subtopology", "type": "string", "versions": "0+",
+        "about": "subtopology ID" },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partition Ids." }
+        "about": "partitions" }
     ]}
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMemberMetadataKey",
+  "validVersions": "5",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "5",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "5",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMemberMetadataKey",
-  "validVersions": "5",
+  "name": "StreamsGroupMemberMetadataKey",
+  "validVersions": "11",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "5",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMemberMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "InstanceId", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The (optional) instance id." },
+    { "name": "RackId", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The (optional) rack id." },
+    { "name": "ClientId", "versions": "0+", "type": "string",
+      "about": "The client id." },
+    { "name": "ClientHost", "versions": "0+", "type": "string",
+      "about": "The client host." },
+    { "name": "SubscribedTopicNames", "versions": "0+", "type": "[]string",
+      "about": "The list of subscribed topic names." },
+    { "name": "SubscribedTopicRegex", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The subscribed topic regular expression." },
+    { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+      "about": "The rebalance timeout" },
+    { "name": "ServerAssignor", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The server assignor to use; or null if not used." },
+    { "name": "ClassicMemberMetadata", "versions": "0+", "nullableVersions": "0+", "type": "ClassicMemberMetadata",
+      "default": null, "taggedVersions": "0+", "tag": 0,
+      "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
+      "fields": [
+        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+",
+          "about": "The session timeout if the consumer uses the classic protocol." },
+        { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
+          "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",
+          "fields": [
+            { "name": "Name", "type": "string", "versions": "0+",
+              "about": "The protocol name."},
+            { "name": "Metadata", "type": "bytes", "versions": "0+",
+              "about": "The protocol metadata."}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -28,29 +28,41 @@
       "about": "The client id." },
     { "name": "ClientHost", "versions": "0+", "type": "string",
       "about": "The client host." },
-    { "name": "SubscribedTopicNames", "versions": "0+", "type": "[]string",
-      "about": "The list of subscribed topic names." },
-    { "name": "SubscribedTopicRegex", "versions": "0+", "nullableVersions": "0+", "type": "string",
-      "about": "The subscribed topic regular expression." },
     { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
       "about": "The rebalance timeout" },
-    { "name": "ServerAssignor", "versions": "0+", "nullableVersions": "0+", "type": "string",
-      "about": "The server assignor to use; or null if not used." },
-    { "name": "ClassicMemberMetadata", "versions": "0+", "nullableVersions": "0+", "type": "ClassicMemberMetadata",
-      "default": null, "taggedVersions": "0+", "tag": 0,
-      "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
+
+    { "name": "TopologyHash", "type": "bytes", "versions": "0+",
+      "about": "The hash of the topology. " },
+    { "name": "Assignor", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": null,
+      "about": "The desired assignor. " },
+
+    { "name": "ProcessId", "type": "string", "versions": "0+",
+      "about": "Identity of the streams instance that may have multiple consumers. " },
+    { "name": "HostInfo", "type": "HostInfo", "versions": "0+",
+      "about": "Host information for running interactive queries on this instance. ",
       "fields": [
-        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+",
-          "about": "The session timeout if the consumer uses the classic protocol." },
-        { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
-          "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",
-          "fields": [
-            { "name": "Name", "type": "string", "versions": "0+",
-              "about": "The protocol name."},
-            { "name": "Metadata", "type": "bytes", "versions": "0+",
-              "about": "The protocol metadata."}
-          ]
-        }
+        { "name": "Host", "type": "string", "versions": "0+",
+          "about": "Host for running interactive queries on this instance." },
+        { "name": "Port", "type": "int32", "versions": "0+",
+          "about": "Port for running interactive queries on this instance." }
+      ]
+    },
+    // TODO: maybe it would be nice to just stuff this info into "AssignmentConfigs", since it's quite specific
+    { "name": "ClientTags", "type": "[]KeyValue", "versions": "0+",
+      "about": "Used for rack-aware assignment algorithm. Null if unchanged since last heartbeat." },
+
+    { "name": "UserData", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "Opaque user data to be passed to the client-side assignor." },
+    { "name": "AssignmentConfigs", "type": "[]KeyValue", "versions": "0+",
+      "about": "Generic array of assignment configuration strings." }
+  ],
+  "commonStructs": [
+    { "name": "KeyValue", "versions": "0+",
+      "fields": [
+        { "name": "Key", "type": "string", "versions": "0+",
+          "about": "key of the config" },
+        { "name": "Value", "type": "string", "versions": "0+",
+          "about": "value of the config" }
       ]
     }
   ]

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMemberMetadataValue",
+  "name": "StreamsGroupMemberMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMemberMetadataValue.json
@@ -29,17 +29,17 @@
     { "name": "ClientHost", "versions": "0+", "type": "string",
       "about": "The client host." },
     { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
-      "about": "The rebalance timeout" },
+      "about": "The rebalance timeout." },
 
     { "name": "TopologyHash", "type": "bytes", "versions": "0+",
       "about": "The hash of the topology. " },
     { "name": "Assignor", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": null,
-      "about": "The desired assignor. " },
+      "about": "The desired assignor. If set to null, the vote goes towards the broker taking a pick." },
 
     { "name": "ProcessId", "type": "string", "versions": "0+",
-      "about": "Identity of the streams instance that may have multiple consumers. " },
+      "about": "Identity of the streams instance that may have multiple consumers." },
     { "name": "HostInfo", "type": "HostInfo", "versions": "0+",
-      "about": "Host information for running interactive queries on this instance. ",
+      "about": "Host information for running interactive queries on this instance.",
       "fields": [
         { "name": "Host", "type": "string", "versions": "0+",
           "about": "Host for running interactive queries on this instance." },
@@ -49,10 +49,10 @@
     },
     // TODO: maybe it would be nice to just stuff this info into "AssignmentConfigs", since it's quite specific
     { "name": "ClientTags", "type": "[]KeyValue", "versions": "0+",
-      "about": "Used for rack-aware assignment algorithm. Null if unchanged since last heartbeat." },
+      "about": "Used for rack-aware assignment algorithm." },
 
     { "name": "UserData", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "default": "null",
-      "about": "Opaque user data to be passed to the client-side assignor." },
+      "about": "Opaque user data to be passed to the client-side assignor. Null for server-side assignors." },
     { "name": "AssignmentConfigs", "type": "[]KeyValue", "versions": "0+",
       "about": "Generic array of assignment configuration strings." }
   ],

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMetadataKey",
+  "validVersions": "3",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "3",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMetadataKey",
-  "validVersions": "3",
+  "name": "StreamsGroupMetadataKey",
+  "validVersions": "9",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "3",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Epoch", "versions": "0+", "type": "int32",
+      "about": "The group epoch." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupMetadataValue",
+  "name": "StreamsGroupMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupPartitionMetadataKey",
+  "validVersions": "4",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "4",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupPartitionMetadataKey",
-  "validVersions": "4",
+  "name": "StreamsGroupPartitionMetadataKey",
+  "validVersions": "10",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "4",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupPartitionMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
+      "about": "The list of topic metadata.", "fields": [
+      { "name": "TopicId", "versions": "0+", "type": "uuid",
+        "about": "The topic id." },
+      { "name": "TopicName", "versions": "0+", "type": "string",
+        "about": "The topic name." },
+      { "name": "NumPartitions", "versions": "0+", "type": "int32",
+        "about": "The number of partitions of the topic." },
+      { "name": "PartitionMetadata", "versions": "0+", "type": "[]PartitionMetadata",
+        "about": "Partitions mapped to a set of racks. If the rack information is unavailable for all the partitions, an empty list is stored", "fields": [
+          { "name": "Partition", "versions": "0+", "type": "int32",
+            "about": "The partition number." },
+          { "name": "Racks", "versions": "0+", "type": "[]string",
+            "about": "The set of racks that the partition is mapped to." }
+      ]}
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupPartitionMetadataValue",
+  "name": "StreamsGroupPartitionMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -20,7 +20,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    // TODO: Do we need to update this???
     { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupPartitionMetadataValue.json
@@ -20,6 +20,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    // TODO: Do we need to update this???
     { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMemberKey",
+  "validVersions": "7",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "7",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "7",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMemberKey",
-  "validVersions": "7",
+  "name": "StreamsGroupTargetAssignmentMemberKey",
+  "validVersions": "13",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "7",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMemberValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "TopicPartitions", "versions": "0+", "type": "[]TopicPartition",
+      "about": "The assigned partitions.", "fields": [
+      { "name": "TopicId", "versions": "0+", "type": "uuid" },
+      { "name": "Partitions", "versions": "0+", "type": "[]int32" }
+    ]}
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMemberValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMemberValue",
+  "name": "StreamsGroupTargetAssignmentMemberValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMetadataKey",
+  "validVersions": "6",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "6",
+      "about": "The group id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataKey.json
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMetadataKey",
-  "validVersions": "6",
+  "name": "StreamsGroupTargetAssignmentMetadataKey",
+  "validVersions": "12",
   "flexibleVersions": "none",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "6",

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupTargetAssignmentMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "AssignmentEpoch", "versions": "0+", "type": "int32",
+      "about": "The assignment epoch." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentMetadataValue.json
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "ConsumerGroupTargetAssignmentMetadataValue",
+  "name": "StreamsGroupTargetAssignmentMetadataValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyKey.json
@@ -16,23 +16,11 @@
 // The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
-  "name": "StreamsGroupTargetAssignmentMemberValue",
-  "validVersions": "0",
-  "flexibleVersions": "0+",
+  "name": "StreamsGroupTopologyKey",
+  "validVersions": "15",
+  "flexibleVersions": "none",
   "fields": [
-    { "name": "ActiveTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned active tasks for this streams client." },
-    { "name": "StandbyTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned standby tasks for this streams client." },
-    { "name": "WarmupTasks", "versions": "0+", "type": "[]TaskId",
-      "about": "Currently assigned warming up tasks for this streams client." }
-  ],
-  "commonStructs": [
-    { "name": "TaskId", "versions": "0+", "fields": [
-      { "name": "Subtopology", "type": "string", "versions": "0+",
-        "about": "The subtopology identifier." },
-      { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partitions of the input topics processed by this member." }
-    ]}
+    { "name": "GroupId", "type": "string", "versions": "3",
+      "about": "The group id." }
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// The streams rebalance protocol is in development. This schema is subject to non-backwards-compatible changes.
 {
-  "apiKey": 77,
-  "type": "request",
-  "listeners": ["zkBroker", "broker"],
-  "name": "StreamsInitializeRequest",
+  "type": "data",
+  "name": "StreamsGroupTopologyValue",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
-      "about": "The group identifier." },
+    { "name": "TopologyHash", "type": "bytes", "versions": "0+",
+      "about": "The hash of the topology. " },
     { "name":  "Topology", "type": "[]Subtopology", "versions": "0+",
       "about": "The sub-topologies of the streams application.",
       "fields": [
@@ -33,19 +32,19 @@
         { "name": "SinkTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology writes to." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
+          "about": "The set of state changelog topics associated with this subtopology. " },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+          "about": "The set of source topics that are internally created repartition topics. " }
       ]
     }
   ],
   "commonStructs": [
     { "name": "TopicConfig", "versions": "0+", "fields": [
-        { "name": "key", "type": "string", "versions": "0+",
-          "about": "The key of the topic-level configuration." },
-        { "name": "value", "type": "string", "versions": "0+",
-          "about": "The value of the topic-level configuration," }
-      ]
+      { "name": "key", "type": "string", "versions": "0+",
+        "about": "The key of the topic-level configuration." },
+      { "name": "value", "type": "string", "versions": "0+",
+        "about": "The value of the topic-level configuration," }
+    ]
     },
     { "name": "TopicInfo", "versions": "0+", "fields": [
       { "name": "Name", "type": "string", "versions": "0+",

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpersTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import org.apache.kafka.common.message.StreamsInitializeRequestData;
-import org.apache.kafka.common.message.StreamsInitializeRequestData.TopicInfo;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/CoordinatorRecordHelpersTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.coordinator.group;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData.TopicInfo;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -44,6 +46,8 @@ import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupMember;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -80,6 +84,7 @@ import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newGro
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newGroupSubscriptionMetadataTombstoneRecord;
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newMemberSubscriptionRecord;
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newMemberSubscriptionTombstoneRecord;
+import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newStreamsGroupTopologyRecord;
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newTargetAssignmentEpochRecord;
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newTargetAssignmentEpochTombstoneRecord;
 import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newTargetAssignmentRecord;
@@ -211,6 +216,84 @@ public class CoordinatorRecordHelpersTest {
 
         assertEquals(expectedRecord, newGroupSubscriptionMetadataTombstoneRecord(
             "group-id"
+        ));
+    }
+
+    @Test
+    public void testNewStreamsGroupTopologyRecord() {
+        List<StreamsInitializeRequestData.Subtopology> topology =
+            Collections.singletonList(new StreamsInitializeRequestData.Subtopology()
+                .setSubtopology("subtopology-id")
+                .setSinkTopics(Collections.singletonList("foo"))
+                .setSourceTopics(Collections.singletonList("bar"))
+                .setRepartitionSourceTopics(
+                    Collections.singletonList(
+                        new StreamsInitializeRequestData.TopicInfo()
+                            .setName("repartition")
+                            .setPartitions(4)
+                            .setTopicConfigs(Collections.singletonList(
+                                new StreamsInitializeRequestData.TopicConfig()
+                                    .setKey("config-name1")
+                                    .setValue("config-value1")
+                            ))
+                    )
+                )
+                .setStateChangelogTopics(
+                    Collections.singletonList(
+                        new StreamsInitializeRequestData.TopicInfo()
+                            .setName("changelog")
+                            .setTopicConfigs(Collections.singletonList(
+                                new StreamsInitializeRequestData.TopicConfig()
+                                    .setKey("config-name2")
+                                    .setValue("config-value2")
+                            ))
+                    )
+                )
+            );
+
+        List<StreamsGroupTopologyValue.Subtopology> expectedTopology =
+            Collections.singletonList(new StreamsGroupTopologyValue.Subtopology()
+                .setSubtopology("subtopology-id")
+                .setSinkTopics(Collections.singletonList("foo"))
+                .setSourceTopics(Collections.singletonList("bar"))
+                .setRepartitionSourceTopics(
+                    Collections.singletonList(
+                        new StreamsGroupTopologyValue.TopicInfo()
+                            .setName("repartition")
+                            .setPartitions(4)
+                            .setTopicConfigs(Collections.singletonList(
+                                new StreamsGroupTopologyValue.TopicConfig()
+                                    .setKey("config-name1")
+                                    .setValue("config-value1")
+                            ))
+                    )
+                )
+                .setStateChangelogTopics(
+                    Collections.singletonList(
+                        new StreamsGroupTopologyValue.TopicInfo()
+                            .setName("changelog")
+                            .setTopicConfigs(Collections.singletonList(
+                                new StreamsGroupTopologyValue.TopicConfig()
+                                    .setKey("config-name2")
+                                    .setValue("config-value2")
+                            ))
+                    )
+                )
+            );
+
+        CoordinatorRecord expectedRecord = new CoordinatorRecord(
+            new ApiMessageAndVersion(
+                new StreamsGroupTopologyKey()
+                    .setGroupId("group-id"),
+                (short) 15),
+            new ApiMessageAndVersion(
+                new StreamsGroupTopologyValue()
+                    .setTopology(expectedTopology),
+                (short) 0));
+
+        assertEquals(expectedRecord, newStreamsGroupTopologyRecord(
+            "group-id",
+            topology
         ));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
@@ -49,6 +50,8 @@ import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -258,6 +261,118 @@ public class GroupCoordinatorServiceTest {
 
         assertEquals(
             new ConsumerGroupHeartbeatResponseData()
+                .setErrorCode(expectedErrorCode)
+                .setErrorMessage(expectedErrorMessage),
+            future.get(5, TimeUnit.SECONDS)
+        );
+    }
+
+    @Test
+    public void testStreamsInitializeWhenNotStarted() throws ExecutionException, InterruptedException {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+
+        StreamsInitializeRequestData request = new StreamsInitializeRequestData()
+            .setGroupId("foo");
+
+        CompletableFuture<StreamsInitializeResponseData> future = service.streamsInitialize(
+            requestContext(ApiKeys.STREAMS_INITIALIZE),
+            request
+        );
+
+        assertEquals(
+            new StreamsInitializeResponseData()
+                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()),
+            future.get()
+        );
+    }
+
+    @Test
+    public void testStreamsInitialize() throws ExecutionException, InterruptedException, TimeoutException {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+
+        StreamsInitializeRequestData request = new StreamsInitializeRequestData()
+            .setGroupId("foo");
+
+        service.startup(() -> 1);
+
+        when(runtime.scheduleWriteOperation(
+            ArgumentMatchers.eq("streams-group-initialize"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.eq(Duration.ofMillis(5000)),
+            ArgumentMatchers.any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsInitializeResponseData()
+        ));
+
+        CompletableFuture<StreamsInitializeResponseData> future = service.streamsInitialize(
+            requestContext(ApiKeys.STREAMS_INITIALIZE),
+            request
+        );
+
+        assertEquals(new StreamsInitializeResponseData(), future.get(5, TimeUnit.SECONDS));
+    }
+
+    private static Stream<Arguments> testStreamsInitializeWithExceptionSource() {
+        return Stream.of(
+            Arguments.arguments(new UnknownTopicOrPartitionException(), Errors.COORDINATOR_NOT_AVAILABLE.code(), null),
+            Arguments.arguments(new NotEnoughReplicasException(), Errors.COORDINATOR_NOT_AVAILABLE.code(), null),
+            Arguments.arguments(new org.apache.kafka.common.errors.TimeoutException(), Errors.COORDINATOR_NOT_AVAILABLE.code(), null),
+            Arguments.arguments(new NotLeaderOrFollowerException(), Errors.NOT_COORDINATOR.code(), null),
+            Arguments.arguments(new KafkaStorageException(), Errors.NOT_COORDINATOR.code(), null),
+            Arguments.arguments(new RecordTooLargeException(), Errors.UNKNOWN_SERVER_ERROR.code(), null),
+            Arguments.arguments(new RecordBatchTooLargeException(), Errors.UNKNOWN_SERVER_ERROR.code(), null),
+            Arguments.arguments(new InvalidFetchSizeException(""), Errors.UNKNOWN_SERVER_ERROR.code(), null),
+            Arguments.arguments(new InvalidRequestException("Invalid"), Errors.INVALID_REQUEST.code(), "Invalid"),
+            Arguments.arguments(new StreamsInvalidTopologyException("Invalid"), Errors.STREAMS_INVALID_TOPOLOGY.code(), "Invalid")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testStreamsInitializeWithExceptionSource")
+    public void testStreamsInitializeWithException(
+        Throwable exception,
+        short expectedErrorCode,
+        String expectedErrorMessage
+    ) throws ExecutionException, InterruptedException, TimeoutException {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+
+        StreamsInitializeRequestData request = new StreamsInitializeRequestData()
+            .setGroupId("foo");
+
+        service.startup(() -> 1);
+
+        when(runtime.scheduleWriteOperation(
+            ArgumentMatchers.eq("streams-group-initialize"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.eq(Duration.ofMillis(5000)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(exception));
+
+        CompletableFuture<StreamsInitializeResponseData> future = service.streamsInitialize(
+            requestContext(ApiKeys.STREAMS_INITIALIZE),
+            request
+        );
+
+        assertEquals(
+            new StreamsInitializeResponseData()
                 .setErrorCode(expectedErrorCode)
                 .setErrorMessage(expectedErrorMessage),
             future.get(5, TimeUnit.SECONDS)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -115,6 +117,38 @@ public class GroupCoordinatorShardTest {
         )).thenReturn(result);
 
         assertEquals(result, coordinator.consumerGroupHeartbeat(context, request));
+    }
+
+    @Test
+    public void testStreamsInitialize() {
+        GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
+        OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
+        CoordinatorMetrics coordinatorMetrics = mock(CoordinatorMetrics.class);
+        CoordinatorMetricsShard metricsShard = mock(CoordinatorMetricsShard.class);
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
+            groupMetadataManager,
+            offsetMetadataManager,
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
+            mock(GroupCoordinatorConfig.class),
+            coordinatorMetrics,
+            metricsShard
+        );
+
+        RequestContext context = requestContext(ApiKeys.STREAMS_INITIALIZE);
+        StreamsInitializeRequestData request = new StreamsInitializeRequestData();
+        CoordinatorResult<StreamsInitializeResponseData, CoordinatorRecord> result = new CoordinatorResult<>(
+            Collections.emptyList(),
+            new StreamsInitializeResponseData()
+        );
+
+        when(groupMetadataManager.streamsInitialize(
+            context,
+            request
+        )).thenReturn(result);
+
+        assertEquals(result, coordinator.streamsInitialize(context, request));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -12992,8 +12992,7 @@ public class GroupMetadataManagerTest {
         assertEquals(
             new StreamsInitializeResponseData()
                 .setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code())
-                .setErrorMessage("Internal topics changelog do not exist.")
-            ,
+                .setErrorMessage("Internal topics changelog do not exist."),
             result.response()
         );
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -50,6 +50,11 @@ import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData;
+import org.apache.kafka.common.message.StreamsInitializeRequestData.Subtopology;
+import org.apache.kafka.common.message.StreamsInitializeRequestData.TopicConfig;
+import org.apache.kafka.common.message.StreamsInitializeRequestData.TopicInfo;
+import org.apache.kafka.common.message.StreamsInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupRequestData.SyncGroupRequestAssignment;
 import org.apache.kafka.common.message.SyncGroupResponseData;
@@ -12858,5 +12863,141 @@ public class GroupMetadataManagerTest {
 
         assertEquals(expectedSuccessCount, successCount);
         return memberIds;
+    }
+
+    @Test
+    public void testTopologyInitialization() {
+        String groupId = "fooup";
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "repartition";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "changelog";
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .build();
+
+        assertThrows(GroupIdNotFoundException.class, () ->
+            context.groupMetadataManager.consumerGroup(groupId));
+
+        final List<Subtopology> topology = Collections.singletonList(
+            new Subtopology()
+                .setSubtopology("subtopology-id")
+                .setSinkTopics(Collections.singletonList("foo"))
+                .setSourceTopics(Collections.singletonList("bar"))
+                .setRepartitionSourceTopics(
+                    Collections.singletonList(
+                        new TopicInfo()
+                            .setName("repartition")
+                            .setPartitions(4)
+                            .setTopicConfigs(Collections.singletonList(
+                                new TopicConfig()
+                                    .setKey("config-name1")
+                                    .setValue("config-value1")
+                            ))
+                    )
+                )
+                .setStateChangelogTopics(
+                    Collections.singletonList(
+                        new TopicInfo()
+                            .setName("changelog")
+                            .setTopicConfigs(Collections.singletonList(
+                                new TopicConfig()
+                                    .setKey("config-name2")
+                                    .setValue("config-value2")
+                            ))
+                    )
+                )
+        );
+        CoordinatorResult<StreamsInitializeResponseData, CoordinatorRecord> result =
+            context.streamsInitialize(
+                new StreamsInitializeRequestData()
+                    .setGroupId(groupId)
+                    .setTopology(topology)
+            );
+
+        assertEquals(
+            new StreamsInitializeResponseData(),
+            result.response()
+        );
+
+        List<CoordinatorRecord> expectedRecords = Arrays.asList(
+            CoordinatorRecordHelpers.newStreamsGroupTopologyRecord(
+                groupId,
+                topology
+            )
+        );
+
+        assertRecordsEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testTopologyInitializationMissingInternalTopics() {
+        String groupId = "fooup";
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "repartition";
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addRacks()
+                .build())
+            .build();
+
+        assertThrows(GroupIdNotFoundException.class, () ->
+            context.groupMetadataManager.consumerGroup(groupId));
+
+        final List<Subtopology> topology = Collections.singletonList(
+            new Subtopology()
+                .setSubtopology("subtopology-id")
+                .setSinkTopics(Collections.singletonList("foo"))
+                .setSourceTopics(Collections.singletonList("bar"))
+                .setRepartitionSourceTopics(
+                    Collections.singletonList(
+                        new TopicInfo()
+                            .setName("repartition")
+                            .setPartitions(4)
+                            .setTopicConfigs(Collections.singletonList(
+                                new TopicConfig()
+                                    .setKey("config-name1")
+                                    .setValue("config-value1")
+                            ))
+                    )
+                )
+                .setStateChangelogTopics(
+                    Collections.singletonList(
+                        new TopicInfo()
+                            .setName("changelog")
+                            .setTopicConfigs(Collections.singletonList(
+                                new TopicConfig()
+                                    .setKey("config-name2")
+                                    .setValue("config-value2")
+                            ))
+                    )
+                )
+        );
+        CoordinatorResult<StreamsInitializeResponseData, CoordinatorRecord> result =
+            context.streamsInitialize(
+                new StreamsInitializeRequestData()
+                    .setGroupId(groupId)
+                    .setTopology(topology)
+            );
+
+        assertEquals(
+            new StreamsInitializeResponseData()
+                .setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code())
+                .setErrorMessage("Internal topics changelog do not exist.")
+            ,
+            result.response()
+        );
+
+        assertTrue(result.records().isEmpty());
+
     }
 }


### PR DESCRIPTION
Implement init streams app call in group coordinator without creating internal topics.

- Create topology metadata record
- Verify existence of all required internal topics

Stacked! Only review changes in the group-coordinator source module

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
